### PR TITLE
docs: add OrcaRouter aggregate gateway provider example to Chapter 3

### DIFF
--- a/pi-agent/pi_sdk_learn/docs/第3章-模型配置的关键-判断企业内网能否接入.md
+++ b/pi-agent/pi_sdk_learn/docs/第3章-模型配置的关键-判断企业内网能否接入.md
@@ -171,7 +171,34 @@ baseUrl 应为:  http://localhost:11434/v1
 
 企业内网接口同理，把 `baseUrl` 改成公司内网地址就行。
 
+#### 4.1.1 案例：接入 OrcaRouter 聚合网关
 
+Ollama 是**本地**的 OpenAI 兼容服务。这里再看一个**云端多模型网关**的例子：OrcaRouter（https://www.orcarouter.ai ）是一个 OpenAI 兼容的 AI 网关，一个 Key、一个 `baseUrl` 背后聚合了几十家厂商的模型（Claude、GPT、DeepSeek、Qwen 等）。对 Pi Agent 来说它和 Ollama 没有本质区别——都是 `openai-completions` 协议，在 `models.json` 里配一个命名 Provider 就能用，不需要把它当「匿名自定义 baseUrl」特殊处理。
+
+配置里 `apiKey` 用 `$ORCAROUTER_API_KEY` 环境变量插值（第 1 章讲过，别把 Key 写死在文件里）：
+
+```json
+{
+  "providers": {
+    "orcarouter": {
+      "baseUrl": "https://api.orcarouter.ai/v1",
+      "api": "openai-completions",
+      "apiKey": "$ORCAROUTER_API_KEY",
+      "models": [
+        { "id": "orcarouter/auto", "name": "OrcaRouter Auto" },
+        { "id": "orcarouter/fusion", "name": "OrcaRouter Fusion" }
+      ]
+    }
+  }
+}
+```
+
+两个细节：
+
+- **模型 ID 用网关自己的命名空间**：OrcaRouter 的模型 ID 自带 `provider/` 前缀，比如 `orcarouter/auto`（按路由规则自动选模型）、`orcarouter/fusion`（多模型融合），以及 `anthropic/claude-sonnet-4-5`、`deepseek/deepseek-r1` 这类直连模型。写进 `models.json` 的 `id` 是什么，`provider/id` 组合就是什么——`getModel("orcarouter", "orcarouter/auto")` 就是精确取这个模型。路由能力由网关负责，Pi Agent 这边不需要感知。
+- **协议要求全部满足**：按 4.2.1 的三条硬性要求核对——`POST /v1/chat/completions` 路径 ✓、SSE 流式 ✓、`Authorization: Bearer` 鉴权 ✓。实测 `stream: true` + `stream_options: { include_usage: true }` + `store: false` 的请求形态（Pi Agent 默认就会这么发）返回 200 且流式正常，流末带 `usage`，用量统计和成本计算都能正常工作。
+
+`baseUrl` 同样只填到 `/v1` 这一级，**不要**带 `/chat/completions`——规则和 Ollama 完全一样。
 
 ### 4.2 企业内网模型：先验证，再接入
 

--- a/pi-agent/web/src/content/modules/pr03-model-config.mdx
+++ b/pi-agent/web/src/content/modules/pr03-model-config.mdx
@@ -181,7 +181,34 @@ baseUrl 应为:  http://localhost:11434/v1
 
 企业内网接口同理，把 `baseUrl` 改成公司内网地址就行。
 
+#### 4.1.1 案例：接入 OrcaRouter 聚合网关
 
+Ollama 是**本地**的 OpenAI 兼容服务。这里再看一个**云端多模型网关**的例子：OrcaRouter（https://www.orcarouter.ai ）是一个 OpenAI 兼容的 AI 网关，一个 Key、一个 `baseUrl` 背后聚合了几十家厂商的模型（Claude、GPT、DeepSeek、Qwen 等）。对 Pi Agent 来说它和 Ollama 没有本质区别——都是 `openai-completions` 协议，在 `models.json` 里配一个命名 Provider 就能用，不需要把它当「匿名自定义 baseUrl」特殊处理。
+
+配置里 `apiKey` 用 `$ORCAROUTER_API_KEY` 环境变量插值（第 1 章讲过，别把 Key 写死在文件里）：
+
+```json
+{
+  "providers": {
+    "orcarouter": {
+      "baseUrl": "https://api.orcarouter.ai/v1",
+      "api": "openai-completions",
+      "apiKey": "$ORCAROUTER_API_KEY",
+      "models": [
+        { "id": "orcarouter/auto", "name": "OrcaRouter Auto" },
+        { "id": "orcarouter/fusion", "name": "OrcaRouter Fusion" }
+      ]
+    }
+  }
+}
+```
+
+两个细节：
+
+- **模型 ID 用网关自己的命名空间**：OrcaRouter 的模型 ID 自带 `provider/` 前缀，比如 `orcarouter/auto`（按路由规则自动选模型）、`orcarouter/fusion`（多模型融合），以及 `anthropic/claude-sonnet-4-5`、`deepseek/deepseek-r1` 这类直连模型。写进 `models.json` 的 `id` 是什么，`provider/id` 组合就是什么——`getModel("orcarouter", "orcarouter/auto")` 就是精确取这个模型。路由能力由网关负责，Pi Agent 这边不需要感知。
+- **协议要求全部满足**：按 4.2.1 的三条硬性要求核对——`POST /v1/chat/completions` 路径 ✓、SSE 流式 ✓、`Authorization: Bearer` 鉴权 ✓。实测 `stream: true` + `stream_options: { include_usage: true }` + `store: false` 的请求形态（Pi Agent 默认就会这么发）返回 200 且流式正常，流末带 `usage`，用量统计和成本计算都能正常工作。
+
+`baseUrl` 同样只填到 `/v1` 这一级，**不要**带 `/chat/completions`——规则和 Ollama 完全一样。
 
 ### 4.2 企业内网模型：先验证，再接入
 


### PR DESCRIPTION
## Summary

This tutorial repo's goal is to teach readers how to build production-grade agents with Pi-Agent by walking through the source and building a real vertical agent. Chapter 3 is where readers learn to wire up model providers — the models.json configuration, API key management, and how to decide whether an internal gateway can be connected.

This PR adds a short, self-contained subsection (§4.1.1) right after the existing Ollama example in Chapter 3. It shows how to connect [OrcaRouter](https://www.orcarouter.ai) as a **named provider** in `models.json`, mirroring the exact pattern the chapter already uses for Ollama / OpenAI-compatible services — `api: "openai-completions"` plus a `baseUrl` and model list. No code changes are required; it is a pure documentation addition to both the downloadable markdown and the web MDX module.

## Why a named provider, not a passthrough

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class named provider means readers can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The example explains two things readers actually need to know:
- OrcaRouter model IDs carry a `provider/` prefix (`orcarouter/auto`, `orcarouter/fusion`, `anthropic/claude-sonnet-4-5`, …), so the `provider/id` pair in `getModel()` matches the gateway namespace directly.
- The endpoint satisfies all three hard requirements from §4.2.1 (POST `/v1/chat/completions`, SSE streaming, `Authorization: Bearer`).

## Verification

- Both `pi-agent/pi_sdk_learn/docs/第3章-*.md` and `pi-agent/web/src/content/modules/pr03-model-config.mdx` were updated in lockstep; `npm run check:sync` reports all 27 md/mdx pairs in sync.
- `npm run check:counterpart` passes.
- `npm run build` (Astro) completes: 30 pages built.
- Live probe against the real OrcaRouter endpoint using the exact request shape Pi-Agent sends (`stream: true` + `stream_options.include_usage` + `store: false`) returns HTTP 200 with a valid SSE stream and a trailing `usage` chunk.

## Files changed

- `pi-agent/pi_sdk_learn/docs/第3章-模型配置的关键-判断企业内网能否接入.md`
- `pi-agent/web/src/content/modules/pr03-model-config.mdx`

---

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
