### PR TITLE
dg-piagent: 版本协议改为动态基线（查最新为准），核对版本更新至 v0.84.4

### DIFF
--- a/skills/dg-piagent/SKILL.md
+++ b/skills/dg-piagent/SKILL.md
@@ -13,28 +13,19 @@ description: |
 
 # pi-agent SDK 开发指南
 
-> ⚠️ **版本基线**: 本 skill 的 API 描述已对齐到 **pi-coding-agent v0.83.0**。
+> ⚠️ **版本基线（动态）**: 本 skill 的 API 描述最近一次人工核对到 **pi-coding-agent v0.84.4**。基线不写死——安装前先查 latest，以查到的最新版为准（见下方版本协议）。
 >
 > **遇 pi-ai import 失败时**，先查 `node_modules/@earendil-works/pi-ai/dist/compat.d.ts` 的 `export *` 列表，确认符号归属哪个入口。
 
 ## 版本协议 ⭐
 
-本 skill 核对到顶部基线版本（当前 **v0.83.0**）。涉及安装/升级 pi-agent 时遵循三步：
+**基线动态**：不写死版本号，每次引导安装前先跑 `npm view @earendil-works/pi-coding-agent version` 查最新，以查到的版本为本次基线。顶部标注的核对版本只是「API 描述最近核对到的版本」。两步：
 
-1. **默认对齐**：引导安装一律用基线版本 `npm install @earendil-works/pi-coding-agent@0.83.0`，**不装 `latest`**——skill 的 API 描述精确核对到基线版本，装 latest 会立即漂移。场景文档里的安装命令同样以基线版本为准。
+1. **查最新、装最新**：跑 `npm view @earendil-works/pi-coding-agent version` 拿 latest，安装该版本（需要可复现时用精确版本号 `@X.Y.Z`，日常可直接 `@latest`）。场景文档里的安装命令一律指最新版。若查到的版本 ≠ 顶部核对版本，走第 2 步核对差异。
 
-2. **升级前评估**：当任务涉及安装/升级（或用户问版本）时，先跑 `npm view @earendil-works/pi-coding-agent version` 拿 latest 与基线对比。若不同，联网查该版本 CHANGELOG/release notes，从 SDK 二次开发角度评估（新功能 / 破坏性变更），给用户简短建议，由用户决定是否升级。日常开发（项目已装好）不触发。
+2. **差异核对**：查 GitHub `github.com/earendil-works/pi` 的 `packages/coding-agent/CHANGELOG.md`（或 Releases），对比核对版本→最新版之间的变更（尤其 Breaking Changes），从 SDK 二次开发角度给用户简短提示。若发现 skill 描述与新 API 有实质出入（类型改名、签名变更、新增重要能力），按 [skill-maintenance.md](references/skill-maintenance.md) 流程产出更新清单，报用户确认后再改 skill，并把顶部核对版本同步为新版。日常开发（项目已装好、不涉及安装）不触发。
 
-3. **升级即更新 skill**：若用户同意升到 X.Y.Z，安装后按 [skill-maintenance.md](references/skill-maintenance.md) 流程，对照新版 `dist/**/*.d.ts` + CHANGELOG 审查 skill 差异，产出更新清单，报用户确认后再改，并同步更新顶部基线版本号。
-
-**变更查阅渠道**（第 2/3 步执行依据）：
-
-| 渠道 | 路径/命令 | 适用阶段 |
-|------|----------|---------|
-| ① node_modules CHANGELOG | `<proj>/node_modules/@earendil-works/pi-coding-agent/CHANGELOG.md`（标准 Keep-a-Changelog，按 `## [版本号]` 分节，含 Breaking Changes）| **升级后**（第3步）|
-| ② GitHub | `github.com/earendil-works/pi` 的 `packages/coding-agent/CHANGELOG.md` 或 Releases | **升级前**（第2步，需联网）|
-
-> 时序关键：升级前 node_modules 仍是旧版，**渠道①看不到新版内容**，第 2 步必须用②（GitHub）。
+> 时序关键：核对差异发生在安装前，node_modules 可能还是旧版或不存在，此时只能用 GitHub CHANGELOG；装好新版后可再用 `<proj>/node_modules/@earendil-works/pi-coding-agent/CHANGELOG.md`（标准 Keep-a-Changelog，按 `## [版本号]` 分节，含 Breaking Changes）与 `dist/**/*.d.ts` 做精确核对。
 
 ## Overview
 
@@ -74,8 +65,10 @@ createAgentSession()  ← 组装入口(Provider + 工具 + 资源)
 ## 快速开始
 
 ```bash
-npm install @earendil-works/pi-coding-agent@0.83.0
+npm install @earendil-works/pi-coding-agent@latest
 ```
+
+> 安装前先 `npm view @earendil-works/pi-coding-agent version` 查最新版为基线，见[版本协议](#版本协议️)
 
 最简示例:
 

--- a/skills/dg-piagent/references/scenarios/A01-minimal-startup.md
+++ b/skills/dg-piagent/references/scenarios/A01-minimal-startup.md
@@ -8,7 +8,7 @@
 
 跑这段代码之前，确保：
 
-1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@0.83.0`
+1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@latest`
 2. **配好 API Key**：见 [场景 B01](B01-auth-config.md)。
    - ⚠️ **注意**：缺 key 时 `createAgentSession()` **不会 throw**——它会返回一个带 `modelFallbackMessage` 警告的 session，真正的报错（`No model selected.`）要等到 `session.prompt()` 时才抛出。这是新手最容易误解的一点：**"创建成功"不等于"能跑通"**。
 3. **有可用模型**：见 [场景 A02](A02-model-selection.md)。未显式传 `model` 时，SDK 按以下顺序找（`findInitialModel`）：① settings 默认模型（已配 key 才算数）→ ② `defaultModelPerProvider`（已知 provider 的默认模型优先匹配）→ ③ 第一个可用模型。三者都失败时，`session.model` 为 `undefined`，`prompt()` 会 throw 多行错误 `No model selected.\n\nUse /login to log into a provider...`。

--- a/skills/dg-piagent/references/scenarios/A02-model-selection.md
+++ b/skills/dg-piagent/references/scenarios/A02-model-selection.md
@@ -15,7 +15,7 @@
 
 ## 前置条件
 
-1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@0.83.0`
+1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@latest`
 2. **配好目标模型的 API Key**：见 [场景 B01](B01-auth-config.md)
    - ⚠️ **注意**：缺 key 时 `createAgentSession()` **不会 throw**——它会返回一个带 `modelFallbackMessage` 警告的 session，真正的报错（`No model selected.` / `No API key found for <provider>.`）要等到 `session.prompt()` 时才抛出。详见 [A01「延迟报错机制」](A01-minimal-startup.md)
 3. **确认模型 ID 存在**：内置模型清单见 pi-ai 包的 `providers/<provider>.models.ts`，或用 [B03](B03-available-models.md) 的代码列出。

--- a/skills/dg-piagent/references/scenarios/A03-system-prompt.md
+++ b/skills/dg-piagent/references/scenarios/A03-system-prompt.md
@@ -16,7 +16,7 @@
 
 ## 前置条件
 
-1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@0.83.0`
+1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@latest`
 2. **确认 cwd 和 agentDir**：
    - `cwd`：项目根目录，决定从哪里开始向上查找 `AGENTS.md`/`CLAUDE.md`
    - `agentDir`：pi 全局配置目录，默认 `~/.pi/agent/`，可用 `getAgentDir()` 获取（受 `PI_CODING_AGENT_DIR` 环境变量覆盖，见 config.ts）

--- a/skills/dg-piagent/references/scenarios/A05-custom-cwd.md
+++ b/skills/dg-piagent/references/scenarios/A05-custom-cwd.md
@@ -15,7 +15,7 @@
 
 ## 前置条件
 
-1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@0.83.0`
+1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@latest`
 2. **确认目标目录存在**：SDK 不会创建目录，`bash` 工具执行时若 cwd 不存在会 throw `Working directory does not exist: <path>`（tools/bash.ts `fsAccess(cwd)` 检查后 throw）
 3. **使用绝对路径**（推荐）：传相对路径会相对**当前 `process.cwd()`** 解析（`resolvePath` 默认 baseDir 是 `process.cwd()`，见 paths.ts），容易意外指错位置
 

--- a/skills/dg-piagent/references/scenarios/A06-load-extensions.md
+++ b/skills/dg-piagent/references/scenarios/A06-load-extensions.md
@@ -16,7 +16,7 @@
 
 ## 前置条件
 
-1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@0.83.0`
+1. **安装 SDK**：`npm install @earendil-works/pi-coding-agent@latest`
 2. **扩展文件语法**：独立 `.ts` / `.js` 文件必须 `export default` 一个 `ExtensionFactory`：
    ```ts
    // my-extension.ts

--- a/skills/dg-piagent/references/scenarios/D01-custom-tool.md
+++ b/skills/dg-piagent/references/scenarios/D01-custom-tool.md
@@ -27,7 +27,7 @@
 | `createAgentSession({ customTools, tools, noTools, excludeTools })` | 注册 + 白名单控制 | [sdk_doc/01-create-agent-session.md](../sdk_doc/01-create-agent-session.md) |
 | `createReadTool` / `createBashTool` 等 | 内置工具的工厂函数（自定义 cwd 或包装） | [sdk_doc/06-tools.md](../sdk_doc/06-tools.md) |
 
-> ⚠️ **import 来源**：TypeBox 从 `typebox` 包导入（**不是** `@sinclair/typebox`，当前 v0.83.0 统一使用 `typebox`）。
+> ⚠️ **import 来源**：TypeBox 从 `typebox` 包导入（**不是** `@sinclair/typebox`，截至核对版本 v0.84.4 统一使用 `typebox`，版本协议见 SKILL.md）。
 > ```ts
 > import { Type } from "typebox";                              // ✅ 正确
 > import { Type } from "@sinclair/typebox";                    // ❌ 旧包名，已废弃

--- a/skills/dg-piagent/references/source-fallback.md
+++ b/skills/dg-piagent/references/source-fallback.md
@@ -87,7 +87,7 @@ grep -rln "<主题>" node_modules/@earendil-works/pi-coding-agent/docs/
 
 如果项目根 `node_modules/@earendil-works/` 不存在：
 
-1. 提示用户 `npm install @earendil-works/pi-coding-agent@0.83.0`
+1. 提示用户 `npm install @earendil-works/pi-coding-agent@latest`
 2. 或退到 GitHub 远程：`github.com/earendil-works/pi` 的 `packages/{coding-agent,agent,ai}/src/`（注意版本可能与项目实际不一致）
 
 ---


### PR DESCRIPTION
## 改动

**1. 版本协议从「写死基线」改为「动态基线」（SKILL.md）**

原协议引导安装固定基线版本（`@0.83.0`）、明确不装 `latest`。问题：skill 内容相对稳定，但基线版本号会持续过时，每次新版发布都要手工同步散落在 7 个文件里的安装命令。

新协议：
- 安装前先跑 `npm view @earendil-works/pi-coding-agent version` 查最新，**以查到的最新版为本次基线**
- 顶部版本号改为「最近一次人工核对版本」语义（信息性，非安装指令）
- 原三步精简为两步：查最新装最新 + 差异核对（对比 GitHub CHANGELOG 核对版本→最新版，有实质出入才按 skill-maintenance 流程更新）
- 场景文档安装命令统一 `@latest`，不再随基线漂移

**2. 核对版本 0.83.0 → 0.84.4**

已对照 0.84.4 的 `dist/**/*.d.ts` 抽查：`agent_settled`、ResourceLoader 的 `getSystemPromptSource`/`getAppendSystemPromptSources`、typebox 导入来源均一致；`turn_end.toolResults` 文档本就与 0.84.0 的 `ToolResultMessage[]` 一致；0.84.3 的 `GoogleThinkingLevel` 改名 skill 未引用，无影响。

## 取舍说明

动态基线牺牲了一点「API 描述与安装版本严格一致」的保证，换取 skill 不随版本发布持续过时；差异核对步骤 + 源码兜底协议（node_modules CHANGELOG / .d.ts）作为漂移防线。若你更倾向保守的写死基线，也可以只合核对版本更新那部分。