### PR TITLE
docs: 补充 dg-piagent skill 缺失的 CHANGELOG.md 和 skill-maintenance.md

### DIFF
--- a/skills/dg-piagent/CHANGELOG.md
+++ b/skills/dg-piagent/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+本文件记录 dg-piagent skill 的变更历史。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-23
+
+### Added
+
+- **SKILL.md** 主文件：Pi-Agent SDK 开发指南，API 核对到 pi-coding-agent v0.83.0
+  - 版本协议（默认对齐 / 升级前评估 / 升级即更新）
+  - 核心心智模型（createAgentSession → session.prompt → subscribe/pi.on）
+  - 事件系统双管道区分（session.subscribe vs pi.on）
+  - 6 个扩展独有事件说明
+  - 工具系统 errors-as-messages 原则
+  - 上下文工程四层漏斗
+  - 会话管理追加写入树
+- **references/scenarios/** — 62 个场景文件，覆盖：
+  - A01-A06：项目初始化、模型选择、Provider 配置、Auth、Full Control、Resource Loader
+  - B01-B04：企业接口评估、内网模型接入、models.json 配置、SSE 流式
+  - C01-C03：Prompt 模板、Context Files、Skills 加载
+  - D01-D06：自定义工具、工具调度、defineTool、TypeBox 集成
+  - E01-E06+E11：扩展工厂、事件监听、拦截模式、pi.on 用法
+  - F01-F05：SessionManager、会话恢复、多会话管理、状态持久化
+  - G01-G04：密钥存储、认证流程、Token 管理
+  - H01-H07：Full Control 模式、ResourceLoader 接口、系统提示词定制
+  - I01-I05：上下文压缩、Token 预算、批量调用、性能优化
+- **references/sdk_doc/** — 22 个 SDK API 参考文档
+- **references/project-structure.md** — Pi-Agent 项目结构说明
+- **references/source-fallback.md** — 源码 fallback 策略
+
+[0.1.0]: https://github.com/buchidonggua/dg-ai-notes/releases/tag/v0.1.0

--- a/skills/dg-piagent/references/skill-maintenance.md
+++ b/skills/dg-piagent/references/skill-maintenance.md
@@ -1,0 +1,139 @@
+# Skill 维护指南
+
+> 本文件定义 dg-piagent skill 的维护原则与升级流程。
+> 当发现信息缺失/错误导致走弯路时，按以下 6 条原则完善本 skill。
+
+---
+
+## 六条维护原则
+
+### 原则 1: 源码优先 (Source-of-Truth)
+
+SDK 行为以 `dist/**/*.d.ts` 类型定义和实际源码为准，不以博客、AI 生成内容或过时文档为准。
+当 skill 描述与源码矛盾时，**修改 skill**。
+
+### 原则 2: 场景驱动 (Scenario-Driven)
+
+新增内容必须关联具体使用场景。不要添加「可能有用」的抽象描述——每个 API 说明都应指向
+对应的 `references/scenarios/` 文件，让用户能直接复制运行。
+
+### 原则 3: 坑要标红 (Gotchas First)
+
+踩坑经验比正面教程更有价值。发现陷阱时：
+1. 在 SKILL.md 对应位置添加 ⚠️ 警告
+2. 在 `references/scenarios/` 中创建专项场景文件
+3. 说明**现象 → 根因 → 防御规则**
+
+### 原则 4: 版本对齐 (Version Alignment)
+
+所有 API 描述必须标注适用版本。新增 API 需注明「vX.Y.Z+」，废弃 API 需注明「vX.Y.Z 起废弃」。
+场景文件顶部标注该场景适用的 SDK 版本范围。
+
+### 原则 5: 渐进披露 (Progressive Disclosure)
+
+- **SKILL.md**（~80 行）：心智模型 + 关键陷阱 + 路由表
+- **references/scenarios/**：按任务类型组织的详细教程
+- **references/sdk_doc/**：API 签名 + 参数说明 + 代码示例
+
+不要把 API 细节塞进 SKILL.md。用户先看到「做什么」，需要时再看「怎么做」。
+
+### 原则 6: 变更留痕 (Change Logging)
+
+每次修改必须同步更新 `CHANGELOG.md`，格式遵循 Keep-a-Changelog：
+- **Added**：新功能/新场景
+- **Changed**：现有内容修改
+- **Fixed**：错误修复
+- **Deprecated**：即将废弃
+
+---
+
+## 升级审查流程
+
+当 pi-coding-agent 发布新版本时，按以下步骤审查 skill 差异：
+
+### Step 1: 检查最新版本
+
+```bash
+npm view @earendil-works/pi-coding-agent version
+```
+
+对比当前基线版本（SKILL.md 顶部标注）。若相同，无需操作。
+
+### Step 2: 获取变更清单
+
+**升级前**（node_modules 仍是旧版）：
+- 查 GitHub：`github.com/earendil-works/pi` → `packages/coding-agent/CHANGELOG.md` 或 Releases
+
+**升级后**（已安装新版）：
+- 查本地：`<proj>/node_modules/@earendil-works/pi-coding-agent/CHANGELOG.md`
+
+### Step 3: 对比 d.ts 类型定义
+
+```bash
+# 对比关键接口变化
+diff <旧版>/dist/types/create-agent-session.d.ts <新版>/dist/types/create-agent-session.d.ts
+diff <旧版>/dist/types/agent-session.d.ts <新版>/dist/types/agent-session.d.ts
+diff <旧版>/dist/types/events.d.ts <新版>/dist/types/events.d.ts
+```
+
+重点关注：
+- 新增/删除的接口方法
+- 参数类型变化
+- 事件名称变化
+- 返回值类型变化
+
+### Step 4: 产出更新清单
+
+根据对比结果，产出以下清单供用户确认：
+
+```markdown
+## 更新清单 vX.Y.Z → vX.Y.Z
+
+### 新增
+- [ ] 新接口 `XxxMethod`：说明 + 场景文件编号
+
+### 变更
+- [ ] `createAgentSession` 参数变化：旧 → 新
+
+### 废弃
+- [ ] `oldMethod` → 用 `newMethod` 替代
+
+### 影响评估
+- 现有场景文件 X 个需更新
+- 新增场景文件 Y 个
+- SKILL.md 需更新 Z 处
+```
+
+### Step 5: 更新 skill
+
+用户确认后：
+1. 更新 SKILL.md 顶部基线版本号
+2. 更新/新增对应的场景文件
+3. 更新 SDK 参考文档
+4. 更新 CHANGELOG.md
+5. 运行验证（场景文件中的代码示例能正常运行）
+
+---
+
+## 目录结构维护
+
+```
+dg-piagent/
+├── SKILL.md                    # 主文件（渐进披露第一层）
+├── CHANGELOG.md                # 变更历史
+└── references/
+    ├── skill-maintenance.md    # 本文件
+    ├── project-structure.md    # 项目结构说明
+    ├── source-fallback.md      # 源码 fallback 策略
+    ├── scenarios/              # 场景文件（按任务类型）
+    │   ├── A01-*.md            # 初始化
+    │   ├── B01-*.md            # 模型接入
+    │   └── ...
+    └── sdk_doc/                # API 参考
+        ├── 01-create-agent-session.md
+        └── ...
+```
+
+新增文件时遵循命名规则：
+- 场景文件：`{编号}-{kebab-case-name}.md`
+- SDK 文档：`{序号}-{kebab-case-name}.md`


### PR DESCRIPTION
## 问题

SKILL.md 中 3 处引用了 `skill-maintenance.md` 和 `CHANGELOG.md`，但这两个文件从未创建：

- 第 28 行：`按 [skill-maintenance.md](references/skill-maintenance.md) 流程...`
- 第 269 行：`按 [skill-maintenance.md](references/skill-maintenance.md) 6 条原则...`
- 第 277 行：`同步更新 [CHANGELOG.md](CHANGELOG.md)（历史沿革，永久保留）`

用户下载 skill 后点击这些链接会 404。

## 修复内容

### CHANGELOG.md
- v0.1.0 初始版本记录
- 列出已有的 62 个场景文件和 22 个 SDK 文档
- 遵循 Keep-a-Changelog 格式

### references/skill-maintenance.md
- 6 条维护原则（源码优先、场景驱动、坑要标红、版本对齐、渐进披露、变更留痕）
- 升级审查流程（检查版本 → 获取变更 → 对比 d.ts → 产出更新清单 → 更新 skill）
- 目录结构维护规范

## 验证

- [x] 两个文件已创建并通过 SKILL.md 中的链接可正常访问
- [x] CHANGELOG.md 格式符合 Keep-a-Changelog 规范
- [x] skill-maintenance.md 中的 6 条原则与 SKILL.md 描述一致
