### PR TITLE
fix: L07 SSE 服务端客户端断开检测改用 res.on(close)

### DIFF
--- a/pi-agent/pi_sdk_learn/code/L07-streaming/07a-sse-server.ts
+++ b/pi-agent/pi_sdk_learn/code/L07-streaming/07a-sse-server.ts
@@ -153,7 +153,7 @@ app.post("/chat", async (req, res) => {
 
   // ③ 客户端断开（关页面、点「停止」中断 fetch）→ 中断 Agent + 清理订阅
   let settled = false;
-  req.on("close", () => {
+  res.on("close", () => {
     off();
     if (!settled) {
       try {


### PR DESCRIPTION
## 问题

Fixes #10

L07 SSE 服务端使用 `req.on("close")` 检测客户端断开，在浏览器 `fetch()` POST + SSE 场景下不可靠：

- 浏览器发送 POST body 后，`req` 流可能已处于 end 状态
- 客户端断开页面时，`req` 的 close 事件行为不可预测
- `res.on("close")` 在响应流写入期间始终可靠触发

## 修复

```diff
- req.on("close", () => {
+ res.on("close", () => {
```

一行修改，`07a-sse-server.ts` 第 156 行。

## 验证

- [x] `res.on("close")` 在 SSE POST 场景下可靠检测客户端断开
- [x] 无需修改前端代码，纯服务端修复
- [x] 修复后客户端断开时能正确触发 `session.abort()` + 清理订阅
