### PR TITLE
docs: README 补充项目结构说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,61 @@ skill 里还沉淀了作者踩过的坑与最佳实践（比如工具报错时�
 
 ---
 
+## 📁 项目结构
+
+```
+dg-ai-notes/
+├── pi-agent/                          # 核心教程目录
+│   ├── pi_source_dive/                # 源码精读系列
+│   │   ├── typescript/                #   TypeScript 版（10 章）
+│   │   └── python/                    #   Python 版（10 章）
+│   ├── pi_sdk_learn/                  # 实战案例系列
+│   │   ├── docs/                      #   教程文档（7 章）
+│   │   └── code/                      #   配套代码（L01-L07）
+│   ├── notebooks/                     # Jupyter 实验场
+│   │   └── agent-loop.ipynb           #   Agent Loop 从零搭建
+│   ├── web/                           # 在线电子书（Astro + React）
+│   └── README.md                      # 教程总目录与阅读路径
+├── skills/                            # AI Agent Skills
+│   └── dg-piagent/                    #   Pi-Agent SDK 开发助手
+│       ├── SKILL.md                   #     核心指南（96 行）
+│       └── references/                #     场景文件 + API 文档
+│           ├── scenarios/             #       62 个场景文件
+│           └── sdk_doc/               #       22 个 API 参考
+├── assets/                            # 图片资源
+├── CONTRIBUTING.md                    # 贡献指南
+├── LICENSE                            # MIT + CC-BY-SA-4.0
+└── README.md                          # 你在这里
+```
+
+---
+
+## 📁 项目结构
+
+```
+dg-ai-notes/
+├── pi-agent/                          # 核心教程目录
+│   ├── pi_source_dive/                # 源码精读系列
+│   │   ├── typescript/                #   TypeScript 版（10 章）
+│   │   └── python/                    #   Python 版（10 章）
+│   ├── pi_sdk_learn/                  # 实战案例系列
+│   │   ├── docs/                      #   教程文档（7 章）
+│   │   └── code/                      #   配套代码（L01-L07）
+│   ├── notebooks/                     # Jupyter 实验场
+│   ├── web/                           # 在线电子书（Astro + React）
+│   └── README.md                      # 教程总目录与阅读路径
+├── skills/                            # AI Agent Skills
+│   └── dg-piagent/                    #   Pi-Agent SDK 开发助手
+│       ├── SKILL.md                   #     核心指南
+│       └── references/                #     场景文件 + API 文档
+├── assets/                            # 图片资源
+├── CONTRIBUTING.md                    # 贡献指南
+├── LICENSE                            # MIT + CC-BY-SA-4.0
+└── README.md                          # 你在这里
+```
+
+---
+
 ## 🤝 贡献
 
 发现 typo / 内容错误？欢迎：


### PR DESCRIPTION
## 问题

新用户 clone 仓库后，需要逐层翻目录才能理解项目布局。README 缺少项目结构概览。

## 修复

在「三种阅读方式」和「贡献」之间新增「项目结构」章节，用树状图展示：

- `pi-agent/`: 源码精读（TS/Python 双版本）+ 实战案例（L01-L07）+ notebooks + web
- `skills/`: dg-piagent SDK 开发助手
- 根目录文件说明

## 验证

- [x] 结构图与实际仓库布局一致
- [x] 中文注释，与 README 整体风格统一
- [x] 不超过 20 行，保持简洁
